### PR TITLE
Index time out at column in jobs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ spec/dummy/db/*.sqlite3-journal
 spec/dummy/log/*.log
 spec/dummy/tmp/
 spec/dummy/.sass-cache
+Gemfile.lock

--- a/db/migrate/20150612082965_add_time_out_index_to_asyncapi_client_job.rb
+++ b/db/migrate/20150612082965_add_time_out_index_to_asyncapi_client_job.rb
@@ -1,0 +1,5 @@
+class AddTimeOutIndexToAsyncapiClientJob < ActiveRecord::Migration
+  def change
+    add_index :asyncapi_client_jobs, :time_out_at
+  end
+end

--- a/spec/dummy/db/migrate/20150612010900_add_time_out_index_to_asyncapi_client_job.asyncapi_client.rb
+++ b/spec/dummy/db/migrate/20150612010900_add_time_out_index_to_asyncapi_client_job.asyncapi_client.rb
@@ -1,0 +1,6 @@
+# This migration comes from asyncapi_client (originally 20150612082965)
+class AddTimeOutIndexToAsyncapiClientJob < ActiveRecord::Migration
+  def change
+    add_index :asyncapi_client_jobs, :time_out_at
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150611040554) do
+ActiveRecord::Schema.define(version: 20150612010900) do
 
   create_table "asyncapi_client_jobs", force: true do |t|
     t.string   "server_job_url"
@@ -31,5 +31,7 @@ ActiveRecord::Schema.define(version: 20150611040554) do
     t.datetime "expired_at"
     t.string   "on_time_out"
   end
+
+  add_index "asyncapi_client_jobs", ["time_out_at"], name: "index_asyncapi_client_jobs_on_time_out_at"
 
 end


### PR DESCRIPTION
Addresses issue where the SQL call to fetch jobs that should be timed out takes 200-400 ms