### PR TITLE
Add `queue_error` state to Job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # TBA
 
 - Add `Asyncapi::Client::Job#response_code`
+- Add Job `fail_queue` event that transitions from `fresh` to `queue_error`
+- Unsuccessful response in JobPostWorker triggers `fail_queue` event
 
 # 0.2.0
 

--- a/app/workers/asyncapi/client/job_post_worker.rb
+++ b/app/workers/asyncapi/client/job_post_worker.rb
@@ -24,7 +24,8 @@ module Asyncapi::Client
           JobStatusWorker.perform_async(job.id)
         end
       else
-        if job.update_attributes(status: :error, message: response.body, response_code: response.response_code)
+        job.fail_queue
+        if job.update_attributes!(message: response.body, response_code: response.response_code)
           JobStatusWorker.perform_async(job.id)
         end
       end

--- a/db/migrate/20150703001225_add_on_queue_error_to_asyncapi_client_jobs.rb
+++ b/db/migrate/20150703001225_add_on_queue_error_to_asyncapi_client_jobs.rb
@@ -1,0 +1,5 @@
+class AddOnQueueErrorToAsyncapiClientJobs < ActiveRecord::Migration
+  def change
+    add_column :asyncapi_client_jobs, :on_queue_error, :string
+  end
+end

--- a/spec/dummy/db/migrate/20150703001225_add_on_queue_error_to_asyncapi_client_jobs.rb
+++ b/spec/dummy/db/migrate/20150703001225_add_on_queue_error_to_asyncapi_client_jobs.rb
@@ -1,0 +1,5 @@
+class AddOnQueueErrorToAsyncapiClientJobs < ActiveRecord::Migration
+  def change
+    add_column :asyncapi_client_jobs, :on_queue_error, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150630011645) do
+ActiveRecord::Schema.define(version: 20150703001225) do
 
   create_table "asyncapi_client_jobs", force: true do |t|
     t.string   "server_job_url"
@@ -31,6 +31,7 @@ ActiveRecord::Schema.define(version: 20150630011645) do
     t.datetime "expired_at"
     t.string   "on_time_out"
     t.integer  "response_code"
+    t.string   "on_queue_error"
   end
 
   add_index "asyncapi_client_jobs", ["time_out_at"], name: "index_asyncapi_client_jobs_on_time_out_at"

--- a/spec/fixtures/on_queue_error.rb
+++ b/spec/fixtures/on_queue_error.rb
@@ -1,0 +1,3 @@
+class OnQueueError
+
+end

--- a/spec/workers/job_post_worker_spec.rb
+++ b/spec/workers/job_post_worker_spec.rb
@@ -52,8 +52,9 @@ module Asyncapi::Client
 
       context "successfully updated job with error" do
         it "updates the job with error and the response body" do
-          expect(job).to receive(:update_attributes).
-            with(status: :error, message: "response body", response_code: 404).
+          expect(job).to receive(:fail_queue)
+          expect(job).to receive(:update_attributes!).
+            with(message: "response body", response_code: 404).
             and_return(true)
           expect(JobStatusWorker).to receive(:perform_async).with(job.id)
           described_class.new.perform(job.id, server_url)
@@ -62,8 +63,9 @@ module Asyncapi::Client
 
       context "unsuccessfuly updated job with error" do
         it "does nothing" do
-          expect(job).to receive(:update_attributes).
-            with(status: :error, message: "response body", response_code: 404).
+          expect(job).to receive(:fail_queue)
+          expect(job).to receive(:update_attributes!).
+            with(message: "response body", response_code: 404).
             and_return(false)
           expect(JobStatusWorker).to_not receive(:perform_async).with(job.id)
           described_class.new.perform(job.id, server_url)


### PR DESCRIPTION
Use case: misconfigured server URL, or the server returns an error upon attempting to queue.  This is distinct from a request being successfully queued, and the server subsequently reporting an error.