### PR TITLE
Map `queue_error` to callback in JobStatusWorker

### DIFF
--- a/app/models/asyncapi/client/job.rb
+++ b/app/models/asyncapi/client/job.rb
@@ -98,5 +98,15 @@ module Asyncapi::Client
       self.secret ||= SecureRandom.uuid
     end
 
+    def self.initial_state
+      self.aasm.state_machine.initial_state
+    end
+
+    def self.non_initial_states
+      self.aasm.states.reject do |state|
+        state == initial_state
+      end.map(&:name)
+    end
+
   end
 end

--- a/app/workers/asyncapi/client/job_status_worker.rb
+++ b/app/workers/asyncapi/client/job_status_worker.rb
@@ -9,6 +9,7 @@ module Asyncapi::Client
       success: :on_success,
       error: :on_error,
       timed_out: :on_time_out,
+      queue_error: :on_queue_error,
     }.with_indifferent_access
 
     def perform(job_id)

--- a/spec/workers/job_status_worker_spec.rb
+++ b/spec/workers/job_status_worker_spec.rb
@@ -3,6 +3,14 @@ require "spec_helper"
 module Asyncapi::Client
   describe JobStatusWorker, "#perform" do
 
+    describe "STATUS_CALLBACK_MAP" do
+      it "has keys for each Job state" do
+        Job.non_initial_states.each do |state|
+          expect(described_class::STATUS_CALLBACK_MAP).to include state
+        end
+      end
+    end
+
     described_class::STATUS_CALLBACK_MAP.each do |status, attr_name|
       it "executes #{attr_name} callback class" do
         callback_class_name = attr_name.to_s.classify


### PR DESCRIPTION
Callback won't be called otherwise.