### PR TITLE
Scope `Job.for_time_out` to `fresh` and `queued` statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Add Job `fail_queue` event that transitions from `fresh` to `queue_error`
 - Unsuccessful response in JobPostWorker triggers `fail_queue` event
 - Remove unneeded scope for `Job.for_time_out`. Has a small speed increase.
+- Scope `Job.for_time_out` to `fresh` and `queued` statuses because it's not possible to transition to `timed_out` from other statuses.
 
 # 0.2.0
 

--- a/app/models/asyncapi/client/job.rb
+++ b/app/models/asyncapi/client/job.rb
@@ -40,7 +40,10 @@ module Asyncapi::Client
 
     scope :expired, -> { where(arel_table[:expired_at].lt(Time.now)) }
     scope :with_time_out, -> { where(arel_table[:time_out_at].not_eq(nil)) }
-    scope :for_time_out, -> { where(arel_table[:time_out_at].lt(Time.now)) }
+    scope :for_time_out, -> do
+      where(arel_table[:time_out_at].lt(Time.now)).
+      where(status: [statuses[:queued], statuses[:fresh]])
+    end
 
     def self.post(url,
                   headers: nil,

--- a/app/workers/asyncapi/client/job_time_out_worker.rb
+++ b/app/workers/asyncapi/client/job_time_out_worker.rb
@@ -9,9 +9,7 @@ module Asyncapi::Client
     recurrence { minutely }
 
     def perform
-      Job.for_time_out.find_each do |job|
-        time_out_job(job) if job.may_time_out?
-      end
+      Job.for_time_out.find_each { |job| time_out_job(job) }
     end
 
     private

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -214,12 +214,24 @@ module Asyncapi::Client
   end
 
   describe ".for_time_out" do
-    let!(:job_1) { create(:asyncapi_client_job, time_out_at: 1.minute.ago) }
-    let!(:job_2) { create(:asyncapi_client_job, time_out_at: 3.hours.from_now) }
-    let!(:job_3) { create(:asyncapi_client_job, time_out_at: nil) }
+    let!(:job_1) do
+      create(:asyncapi_client_job, time_out_at: 1.minute.ago, status: 'fresh')
+    end
+    let!(:job_2) do
+      create(:asyncapi_client_job, time_out_at: 3.hours.from_now, status: 'fresh')
+    end
+    let!(:job_3) do
+      create(:asyncapi_client_job, time_out_at: nil, status: 'queued')
+    end
+    let!(:job_4) do
+      create(:asyncapi_client_job, time_out_at: 2.minutes.ago, status: 'queued')
+    end
+    let!(:job_5) do
+      create(:asyncapi_client_job, time_out_at: 3.minutes.ago, status: 'error')
+    end
 
     it "returns jobs that should be timed out" do
-      expect(Job.for_time_out).to match_array([job_1])
+      expect(Job.for_time_out).to match_array([job_1, job_4])
     end
   end
 


### PR DESCRIPTION
It's not possible to transition to `timed_out` from other statuses.