### PR TITLE
Use `sidekiq-cron` for scheduling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+services:
+  - redis
 language: ruby
 rvm:
   - 2.1.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# TBA
+
+- Use `sidekiq-cron` for scheduling.
+
 # 0.3.0
 
 - Add `Asyncapi::Client::Job#response_code`

--- a/app/workers/asyncapi/client/job_time_out_worker.rb
+++ b/app/workers/asyncapi/client/job_time_out_worker.rb
@@ -2,11 +2,8 @@ module Asyncapi::Client
   class JobTimeOutWorker
 
     include Sidekiq::Worker
-    include Sidetiq::Schedulable
 
     sidekiq_options retry: false
-
-    recurrence { minutely }
 
     def perform
       Job.for_time_out.find_each { |job| time_out_job(job) }
@@ -21,3 +18,9 @@ module Asyncapi::Client
 
   end
 end
+
+Sidekiq::Cron::Job.create({
+  name: "Expire jobs",
+  cron: "*/1 * * * *",
+  klass: "Asyncapi::Client::JobTimeOutWorker",
+})

--- a/asyncapi-client.gemspec
+++ b/asyncapi-client.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails", "~> 4.1.5"
   s.add_dependency "sidekiq"
-  s.add_dependency "sidetiq"
+  s.add_dependency "sidekiq-cron"
   s.add_dependency "kaminari"
   s.add_dependency "api-pagination"
   s.add_dependency "typhoeus"

--- a/lib/asyncapi/client.rb
+++ b/lib/asyncapi/client.rb
@@ -1,5 +1,5 @@
 require "sidekiq"
-require "sidetiq"
+require "sidekiq-cron"
 require "api-pagination"
 require "typhoeus"
 require 'aasm'


### PR DESCRIPTION
`sidetiq`, the library we used to use, is not actively maintained. It also has an issue that prevents some users of this library to upgrade.

https://github.com/tobiassvn/sidetiq/issues/140