### PR TITLE
Don't require redis immediately.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
-services:
-  - redis
 language: ruby
 rvm:
   - 2.1.1

--- a/app/workers/asyncapi/client/job_time_out_worker.rb
+++ b/app/workers/asyncapi/client/job_time_out_worker.rb
@@ -19,8 +19,10 @@ module Asyncapi::Client
   end
 end
 
-Sidekiq::Cron::Job.create({
-  name: "Expire jobs",
-  cron: "*/1 * * * *",
-  klass: "Asyncapi::Client::JobTimeOutWorker",
-})
+if Sidekiq.server?
+  Sidekiq::Cron::Job.create({
+    name: "Expire jobs",
+    cron: "*/1 * * * *",
+    klass: "Asyncapi::Client::JobTimeOutWorker",
+  })
+end


### PR DESCRIPTION
This is a check I've stolen from another G5 project where it was used
successfully to only load jobs in a context where it makes sense. I'm
running into issues where an app that uses this engine is failing during
asset precompilation because redis doesn't exist, which is a context
where I wouldn't expect redis to be required. Adding this check means
that it will only run this code in a process that thinks it's a sidekiq
server, where having redis configured is a reasonable requirement. I
can't think of any negative side effects.

I'm also removing the redis requirement from travis, since it seems like
it isn't necessary now. My tests are passing locally without redis.

I'd like to make this part of an 0.5.1 release if possible. It's a blocker for Dockerizing applications that use this gem, since the build environment (where I'm precompiling assets) doesn't have a running redis server. Thanks!