### PR TITLE
Delete old jobs every day instead of every time a job is created

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+### Changed
+- Cleaner worker is scheduled to run every day instead of every time a job is created
+
 ## [0.5.1] - 2016-05-18
 ### Fixed
 - [Do not include redis immediately](https://github.com/G5/asyncapi-client/pull/20)

--- a/README.md
+++ b/README.md
@@ -73,7 +73,13 @@ By default, jobs 10 days old and older will be deleted. You can change this sett
 Asyncapi::Client.expiry_threshold = 5.days
 ```
 
-If you don't ever want the jobs to get delete, set the threshold to `nil`.
+If you don't want the jobs to get deleted, set the threshold to `nil`.
+
+The cleaner job is run every day at "0 0 * * *". If you want to change the frequency that this runs, then:
+
+```ruby
+Asyncapi::Client.clean_job_cron = "30 2 * * *"
+```
 
 # Installation
 

--- a/app/models/asyncapi/client/job.rb
+++ b/app/models/asyncapi/client/job.rb
@@ -71,7 +71,6 @@ module Asyncapi::Client
       args[:time_out_at] = time_out.from_now if time_out
       job = create(args)
       JobPostWorker.perform_async(job.id, url)
-      CleanerWorker.perform_async
     end
 
     def url

--- a/app/workers/asyncapi/client/cleaner_worker.rb
+++ b/app/workers/asyncapi/client/cleaner_worker.rb
@@ -14,3 +14,11 @@ module Asyncapi
     end
   end
 end
+
+if Sidekiq.server?
+  Sidekiq::Cron::Job.create({
+    name: "Delete old jobs",
+    cron: Asyncapi::Client.clean_job_cron,
+    klass: Asyncapi::Client::CleanerWorker.name,
+  })
+end

--- a/lib/asyncapi/client.rb
+++ b/lib/asyncapi/client.rb
@@ -9,9 +9,10 @@ require "securerandom"
 module Asyncapi
   module Client
 
-    CONFIG_ATTRS = [:parent_controller, :expiry_threshold]
+    CONFIG_ATTRS = %i[parent_controller expiry_threshold clean_job_cron]
     mattr_accessor(*CONFIG_ATTRS)
     self.expiry_threshold = 10.days
+    self.clean_job_cron = "0 0 * * *"
 
     def self.configure
       yield self

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -29,5 +29,11 @@ module Asyncapi
       end
     end
 
+    describe ".clean_job_cron" do
+      it "defaults to '0 0 * * *'" do
+        expect(described_class.clean_job_cron).to eq "0 0 * * *"
+      end
+    end
+
   end
 end

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -121,7 +121,6 @@ module Asyncapi::Client
         job = described_class.last
 
         expect(JobPostWorker).to have_enqueued_job(job.id, server_url)
-        expect(CleanerWorker).to have_enqueued_job
 
         expect(job.follow_up_at.to_i).to eq follow_up.from_now.to_i
         expect(job.time_out_at.to_i).to eq time_out.from_now.to_i
@@ -154,7 +153,6 @@ module Asyncapi::Client
           job = described_class.last
 
           expect(JobPostWorker).to have_enqueued_job(job.id, server_url)
-          expect(CleanerWorker).to have_enqueued_job
 
           expect(job.follow_up_at.to_i).to eq follow_up.from_now.to_i
           expect(job.on_queue).to eq "OnQueue"


### PR DESCRIPTION
This avoids many cleaner jobs from being created when many jobs are posted to the server