### PR TITLE
Add current attribute to asyncapi client jobs

### DIFF
--- a/app/models/asyncapi/client/job.rb
+++ b/app/models/asyncapi/client/job.rb
@@ -55,7 +55,8 @@ module Asyncapi::Client
                   on_queue_error: nil,
                   callback_params: {},
                   follow_up: 5.minutes,
-                  time_out: nil)
+                  time_out: nil,
+                  current: nil)
 
       args = {
         follow_up_at: follow_up.from_now,
@@ -67,6 +68,7 @@ module Asyncapi::Client
         callback_params: callback_params,
         headers: headers,
         body: body,
+        current: current
       }
       args[:time_out_at] = time_out.from_now if time_out
       job = create(args)

--- a/asyncapi-client.gemspec
+++ b/asyncapi-client.gemspec
@@ -17,11 +17,11 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,spec/factories}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   s.add_dependency "rails", "~> 4.0"
-  s.add_dependency "sidekiq"
-  s.add_dependency "sidekiq-cron"
-  s.add_dependency "kaminari"
-  s.add_dependency "api-pagination"
-  s.add_dependency "typhoeus"
+  s.add_dependency "sidekiq", "~> 4.2.10"
+  s.add_dependency "sidekiq-cron", "0.6.3"
+  s.add_dependency "kaminari", "~> 1.0.1"
+  s.add_dependency "api-pagination", "~> 4.6.3"
+  s.add_dependency "typhoeus", "~> 1.1.2"
   s.add_dependency "aasm", ">= 4.0"
   s.add_dependency "ar_after_transaction"
 

--- a/db/migrate/20170707025322_add_current_to_asyncapi_client_job.rb
+++ b/db/migrate/20170707025322_add_current_to_asyncapi_client_job.rb
@@ -1,0 +1,5 @@
+class AddCurrentToAsyncapiClientJob < ActiveRecord::Migration
+  def change
+    add_column :asyncapi_client_jobs, :current, :boolean
+  end
+end

--- a/spec/dummy/db/migrate/20170710010230_add_current_to_asyncapi_client_job.asyncapi_client.rb
+++ b/spec/dummy/db/migrate/20170710010230_add_current_to_asyncapi_client_job.asyncapi_client.rb
@@ -1,0 +1,6 @@
+# This migration comes from asyncapi_client (originally 20170707025322)
+class AddCurrentToAsyncapiClientJob < ActiveRecord::Migration
+  def change
+    add_column :asyncapi_client_jobs, :current, :boolean
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150703001225) do
+ActiveRecord::Schema.define(version: 20170710010230) do
 
   create_table "asyncapi_client_jobs", force: :cascade do |t|
     t.string   "server_job_url"
@@ -32,6 +32,7 @@ ActiveRecord::Schema.define(version: 20150703001225) do
     t.string   "on_time_out"
     t.integer  "response_code"
     t.string   "on_queue_error"
+    t.boolean  "current"
   end
 
   add_index "asyncapi_client_jobs", ["time_out_at"], name: "index_asyncapi_client_jobs_on_time_out_at"


### PR DESCRIPTION
Optional attribute that can be used to tag the latest job for a user-defined scope.