### PR TITLE
[#148359271] Enforce params to always be in String format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - 2.1.1
+  - 2.3.0
 before_script:
   - (cd spec/dummy && bundle exec rake db:schema:load)

--- a/app/workers/asyncapi/client/job_post_worker.rb
+++ b/app/workers/asyncapi/client/job_post_worker.rb
@@ -42,6 +42,7 @@ module Asyncapi::Client
     end
 
     def server_params_from(job, params)
+      params = params.to_json if params.is_a? Hash
       {
         job: {
           callback_url: job.url,


### PR DESCRIPTION
### Changes Proposed in this Pull Request:
* By default, body (params) is of text format thus is sent over api request as string.
Recent changes to ETL converts the database type of job.body from text to json.
As a result, params is now sent over api request as a hash/json and is breaking
Inventory syncs.

### Important Links (Pivotal, Additional Repositories, etc):
* https://www.pivotaltracker.com/n/projects/954618/stories/148359271

### Additional Information (Optional)
* 