### PR TITLE
[#163986377] Fix expired jobs cleanup.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.8.0] - 2019-02-18
+### Changed
+- Fixes jobs deletion in cleanup when there are remote job parameters missing.
+- Add a more efficient way to retrieve jobs for cleanup.
+- Update migrations to be Rails 5 compliant.
+### Added
+- Add index to jobs table on `expired_at` attribute.
+
 ## [0.7.0] - 2018-04-03
 ### Changed
 - Update ruby to 2.3.1

--- a/app/workers/asyncapi/client/cleaner_worker.rb
+++ b/app/workers/asyncapi/client/cleaner_worker.rb
@@ -6,8 +6,8 @@ module Asyncapi
       sidekiq_options retry: false
 
       def perform
-        Job.expired.find_each do |job|
-          JobCleanerWorker.perform_async(job.id)
+        Job.expired.select(:id).in_batches.each do |job_group|
+          job_group.pluck(:id).each{ |job_id| JobCleanerWorker.perform_async(job_id) }
         end
       end
 

--- a/app/workers/asyncapi/client/cleaner_worker.rb
+++ b/app/workers/asyncapi/client/cleaner_worker.rb
@@ -6,9 +6,7 @@ module Asyncapi
       sidekiq_options retry: false
 
       def perform
-        Job.expired.select(:id).in_batches.each do |job_group|
-          job_group.pluck(:id).each{ |job_id| JobCleanerWorker.perform_async(job_id) }
-        end
+        Job.expired.pluck(:id).each{ |job_id| JobCleanerWorker.perform_async(job_id) }
       end
 
     end

--- a/app/workers/asyncapi/client/job_cleaner_worker.rb
+++ b/app/workers/asyncapi/client/job_cleaner_worker.rb
@@ -7,7 +7,7 @@ module Asyncapi
 
       def perform(job_id)
         if job = Job.find_by(id: job_id)
-          destroy_remote job
+          destroy_remote(job)
           job.destroy
         end
       end
@@ -15,12 +15,46 @@ module Asyncapi
       private
 
       def destroy_remote(job)
-        Typhoeus.delete(job.server_job_url, {
-          params: { secret: job.secret },
-          headers: job.headers,
-        })
+        errors = validate_remote_job_info(job)
+        if errors.empty?
+          Typhoeus.delete(job.server_job_url, {
+            params: { secret: job.secret },
+            headers: job.headers,
+          })
+        else
+          log_remote_error_for(job, errors)
+        end
       end
 
+      def validate_remote_job_info(job)
+        errors = []
+        errors << "server_job_url is invalid"         unless url_ok_for?(job)
+        errors << "authorization headers are not present" unless headers_ok_for?(job)
+        errors << "secret is not present"                unless job.secret.present?
+        errors
+      end
+
+      def url_ok_for?(job)
+        uri = URI.parse(job.server_job_url)
+        uri.is_a?(URI::HTTP) && !uri.host.nil?
+      rescue URI::InvalidURIError
+        false
+      end
+
+      def headers_ok_for?(job)
+        job.headers.is_a?(Hash) && job.headers[:AUTHORIZATION]
+      end
+
+      def log_remote_error_for(job, errors)
+        if defined?(G5::Logger::Log)
+          G5::Logger::Log.send(:warn, {
+            origin: "#{self.class.name}#destroy_remote",
+            external_parent_id: "#{job.id}",
+            message: "Not enough info to delete expired remote job: #{errors.join(", ")}",
+            error: "Unable to delete remote job",
+          })
+        end
+      end
     end
   end
 end

--- a/asyncapi-client.gemspec
+++ b/asyncapi-client.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_dependency "aasm", ">= 4.0"
   s.add_dependency "ar_after_transaction"
 
-  s.add_development_dependency "sqlite3"
+  s.add_development_dependency "sqlite3", '~> 1.3.6'
   s.add_development_dependency "rspec-rails"
   s.add_development_dependency "rspec-its"
   s.add_development_dependency "pry"

--- a/db/migrate/20141104030959_create_asyncapi_client_jobs.rb
+++ b/db/migrate/20141104030959_create_asyncapi_client_jobs.rb
@@ -1,4 +1,4 @@
-class CreateAsyncapiClientJobs < ActiveRecord::Migration[5.0]
+class CreateAsyncapiClientJobs < ActiveRecord::Migration[4.2]
   def change
     create_table :asyncapi_client_jobs do |t|
       t.string   "server_job_url"

--- a/db/migrate/20141104030959_create_asyncapi_client_jobs.rb
+++ b/db/migrate/20141104030959_create_asyncapi_client_jobs.rb
@@ -1,4 +1,4 @@
-class CreateAsyncapiClientJobs < ActiveRecord::Migration
+class CreateAsyncapiClientJobs < ActiveRecord::Migration[5.0]
   def change
     create_table :asyncapi_client_jobs do |t|
       t.string   "server_job_url"

--- a/db/migrate/20141119011011_add_callback_params_to_asyncapi_client_jobs.rb
+++ b/db/migrate/20141119011011_add_callback_params_to_asyncapi_client_jobs.rb
@@ -1,4 +1,4 @@
-class AddCallbackParamsToAsyncapiClientJobs < ActiveRecord::Migration[5.0]
+class AddCallbackParamsToAsyncapiClientJobs < ActiveRecord::Migration[4.2]
   def change
     add_column :asyncapi_client_jobs, :callback_params, :text
   end

--- a/db/migrate/20141119011011_add_callback_params_to_asyncapi_client_jobs.rb
+++ b/db/migrate/20141119011011_add_callback_params_to_asyncapi_client_jobs.rb
@@ -1,4 +1,4 @@
-class AddCallbackParamsToAsyncapiClientJobs < ActiveRecord::Migration
+class AddCallbackParamsToAsyncapiClientJobs < ActiveRecord::Migration[5.0]
   def change
     add_column :asyncapi_client_jobs, :callback_params, :text
   end

--- a/db/migrate/20141212064041_add_secret_to_asyncapi_client_job.rb
+++ b/db/migrate/20141212064041_add_secret_to_asyncapi_client_job.rb
@@ -1,4 +1,4 @@
-class AddSecretToAsyncapiClientJob < ActiveRecord::Migration
+class AddSecretToAsyncapiClientJob < ActiveRecord::Migration[5.0]
   def change
     add_column :asyncapi_client_jobs, :secret, :string
   end

--- a/db/migrate/20141212064041_add_secret_to_asyncapi_client_job.rb
+++ b/db/migrate/20141212064041_add_secret_to_asyncapi_client_job.rb
@@ -1,4 +1,4 @@
-class AddSecretToAsyncapiClientJob < ActiveRecord::Migration[5.0]
+class AddSecretToAsyncapiClientJob < ActiveRecord::Migration[4.2]
   def change
     add_column :asyncapi_client_jobs, :secret, :string
   end

--- a/db/migrate/20150202062211_add_expired_at_to_asyncapi_client_job.rb
+++ b/db/migrate/20150202062211_add_expired_at_to_asyncapi_client_job.rb
@@ -1,4 +1,4 @@
-class AddExpiredAtToAsyncapiClientJob < ActiveRecord::Migration[5.0]
+class AddExpiredAtToAsyncapiClientJob < ActiveRecord::Migration[4.2]
   def change
     add_column :asyncapi_client_jobs, :expired_at, :datetime
   end

--- a/db/migrate/20150202062211_add_expired_at_to_asyncapi_client_job.rb
+++ b/db/migrate/20150202062211_add_expired_at_to_asyncapi_client_job.rb
@@ -1,4 +1,4 @@
-class AddExpiredAtToAsyncapiClientJob < ActiveRecord::Migration
+class AddExpiredAtToAsyncapiClientJob < ActiveRecord::Migration[5.0]
   def change
     add_column :asyncapi_client_jobs, :expired_at, :datetime
   end

--- a/db/migrate/20150202062320_populate_asyncapi_client_job_expired_at.rb
+++ b/db/migrate/20150202062320_populate_asyncapi_client_job_expired_at.rb
@@ -1,4 +1,4 @@
-class PopulateAsyncapiClientJobExpiredAt < ActiveRecord::Migration[5.0]
+class PopulateAsyncapiClientJobExpiredAt < ActiveRecord::Migration[4.2]
   def change
     Asyncapi::Client::Job.find_each do |job|
       job.update_attributes(expired_at: Asyncapi::Client.expiry_threshold.from_now)

--- a/db/migrate/20150202062320_populate_asyncapi_client_job_expired_at.rb
+++ b/db/migrate/20150202062320_populate_asyncapi_client_job_expired_at.rb
@@ -1,4 +1,4 @@
-class PopulateAsyncapiClientJobExpiredAt < ActiveRecord::Migration
+class PopulateAsyncapiClientJobExpiredAt < ActiveRecord::Migration[5.0]
   def change
     Asyncapi::Client::Job.find_each do |job|
       job.update_attributes(expired_at: Asyncapi::Client.expiry_threshold.from_now)

--- a/db/migrate/20150610053320_add_on_time_out_to_asyncapi_client_job.rb
+++ b/db/migrate/20150610053320_add_on_time_out_to_asyncapi_client_job.rb
@@ -1,4 +1,4 @@
-class AddOnTimeOutToAsyncapiClientJob < ActiveRecord::Migration
+class AddOnTimeOutToAsyncapiClientJob < ActiveRecord::Migration[5.0]
   def change
     add_column :asyncapi_client_jobs, :on_time_out, :string
   end

--- a/db/migrate/20150610053320_add_on_time_out_to_asyncapi_client_job.rb
+++ b/db/migrate/20150610053320_add_on_time_out_to_asyncapi_client_job.rb
@@ -1,4 +1,4 @@
-class AddOnTimeOutToAsyncapiClientJob < ActiveRecord::Migration[5.0]
+class AddOnTimeOutToAsyncapiClientJob < ActiveRecord::Migration[4.2]
   def change
     add_column :asyncapi_client_jobs, :on_time_out, :string
   end

--- a/db/migrate/20150612082965_add_time_out_index_to_asyncapi_client_job.rb
+++ b/db/migrate/20150612082965_add_time_out_index_to_asyncapi_client_job.rb
@@ -1,4 +1,4 @@
-class AddTimeOutIndexToAsyncapiClientJob < ActiveRecord::Migration
+class AddTimeOutIndexToAsyncapiClientJob < ActiveRecord::Migration[5.0]
   def change
     add_index :asyncapi_client_jobs, :time_out_at
   end

--- a/db/migrate/20150612082965_add_time_out_index_to_asyncapi_client_job.rb
+++ b/db/migrate/20150612082965_add_time_out_index_to_asyncapi_client_job.rb
@@ -1,4 +1,4 @@
-class AddTimeOutIndexToAsyncapiClientJob < ActiveRecord::Migration[5.0]
+class AddTimeOutIndexToAsyncapiClientJob < ActiveRecord::Migration[4.2]
   def change
     add_index :asyncapi_client_jobs, :time_out_at
   end

--- a/db/migrate/20150630004215_add_response_code_to_asyncapi_client_jobs.rb
+++ b/db/migrate/20150630004215_add_response_code_to_asyncapi_client_jobs.rb
@@ -1,4 +1,4 @@
-class AddResponseCodeToAsyncapiClientJobs < ActiveRecord::Migration
+class AddResponseCodeToAsyncapiClientJobs < ActiveRecord::Migration[5.0]
   def change
     add_column :asyncapi_client_jobs, :response_code, :integer
   end

--- a/db/migrate/20150630004215_add_response_code_to_asyncapi_client_jobs.rb
+++ b/db/migrate/20150630004215_add_response_code_to_asyncapi_client_jobs.rb
@@ -1,4 +1,4 @@
-class AddResponseCodeToAsyncapiClientJobs < ActiveRecord::Migration[5.0]
+class AddResponseCodeToAsyncapiClientJobs < ActiveRecord::Migration[4.2]
   def change
     add_column :asyncapi_client_jobs, :response_code, :integer
   end

--- a/db/migrate/20150703001225_add_on_queue_error_to_asyncapi_client_jobs.rb
+++ b/db/migrate/20150703001225_add_on_queue_error_to_asyncapi_client_jobs.rb
@@ -1,4 +1,4 @@
-class AddOnQueueErrorToAsyncapiClientJobs < ActiveRecord::Migration
+class AddOnQueueErrorToAsyncapiClientJobs < ActiveRecord::Migration[5.0]
   def change
     add_column :asyncapi_client_jobs, :on_queue_error, :string
   end

--- a/db/migrate/20150703001225_add_on_queue_error_to_asyncapi_client_jobs.rb
+++ b/db/migrate/20150703001225_add_on_queue_error_to_asyncapi_client_jobs.rb
@@ -1,4 +1,4 @@
-class AddOnQueueErrorToAsyncapiClientJobs < ActiveRecord::Migration[5.0]
+class AddOnQueueErrorToAsyncapiClientJobs < ActiveRecord::Migration[4.2]
   def change
     add_column :asyncapi_client_jobs, :on_queue_error, :string
   end

--- a/db/migrate/20190218200630_add_expired_at_index_to_asyncapi_client_jobs.rb
+++ b/db/migrate/20190218200630_add_expired_at_index_to_asyncapi_client_jobs.rb
@@ -1,8 +1,5 @@
 class AddExpiredAtIndexToAsyncapiClientJobs < ActiveRecord::Migration[5.0]
-# class AddExpiredAtIndexToAsyncapiClientJobs < ActiveRecord::Migration
   def change
-    def change
-      add_index :asyncapi_client_jobs, :expired_at
-    end
+    add_index :asyncapi_client_jobs, :expired_at
   end
 end

--- a/db/migrate/20190218200630_add_expired_at_index_to_asyncapi_client_jobs.rb
+++ b/db/migrate/20190218200630_add_expired_at_index_to_asyncapi_client_jobs.rb
@@ -1,0 +1,8 @@
+class AddExpiredAtIndexToAsyncapiClientJobs < ActiveRecord::Migration[5.0]
+# class AddExpiredAtIndexToAsyncapiClientJobs < ActiveRecord::Migration
+  def change
+    def change
+      add_index :asyncapi_client_jobs, :expired_at
+    end
+  end
+end

--- a/db/migrate/20190218200630_add_expired_at_index_to_asyncapi_client_jobs.rb
+++ b/db/migrate/20190218200630_add_expired_at_index_to_asyncapi_client_jobs.rb
@@ -1,5 +1,11 @@
 class AddExpiredAtIndexToAsyncapiClientJobs < ActiveRecord::Migration[5.0]
+  disable_ddl_transaction!
+
   def change
-    add_index :asyncapi_client_jobs, :expired_at
+    opts = {}
+    if !!(ActiveRecord::Base.connection_config[:adapter] =~ /postgresql/i)
+      opts[:algorithm] = :concurrently
+    end
+    add_index :asyncapi_client_jobs, :expired_at, opts
   end
 end

--- a/lib/asyncapi/client/version.rb
+++ b/lib/asyncapi/client/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Client
-    VERSION = "0.8.0-beta.1"
+    VERSION = "0.8.0-beta.2"
   end
 end

--- a/lib/asyncapi/client/version.rb
+++ b/lib/asyncapi/client/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Client
-    VERSION = "0.7.0"
+    VERSION = "0.8.0-beta.1"
   end
 end

--- a/lib/asyncapi/client/version.rb
+++ b/lib/asyncapi/client/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Client
-    VERSION = "0.8.0-beta.2"
+    VERSION = "0.8.0-beta.3"
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_200630) do
+ActiveRecord::Schema.define(version: 2015_07_03_001225) do
 
   create_table "asyncapi_client_jobs", force: :cascade do |t|
     t.string "server_job_url"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2015_07_03_001225) do
+ActiveRecord::Schema.define(version: 2019_02_18_200630) do
 
   create_table "asyncapi_client_jobs", force: :cascade do |t|
     t.string "server_job_url"
@@ -23,8 +23,8 @@ ActiveRecord::Schema.define(version: 2015_07_03_001225) do
     t.string "on_error"
     t.text "body"
     t.text "headers"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at"
+    t.datetime "updated_at"
     t.text "callback_params"
     t.string "secret"
     t.datetime "expired_at"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,29 +10,29 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150703001225) do
+ActiveRecord::Schema.define(version: 2019_02_18_200630) do
 
   create_table "asyncapi_client_jobs", force: :cascade do |t|
-    t.string   "server_job_url"
-    t.integer  "status"
-    t.text     "message"
+    t.string "server_job_url"
+    t.integer "status"
+    t.text "message"
     t.datetime "follow_up_at"
     t.datetime "time_out_at"
-    t.string   "on_queue"
-    t.string   "on_success"
-    t.string   "on_error"
-    t.text     "body"
-    t.text     "headers"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.text     "callback_params"
-    t.string   "secret"
+    t.string "on_queue"
+    t.string "on_success"
+    t.string "on_error"
+    t.text "body"
+    t.text "headers"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.text "callback_params"
+    t.string "secret"
     t.datetime "expired_at"
-    t.string   "on_time_out"
-    t.integer  "response_code"
-    t.string   "on_queue_error"
+    t.string "on_time_out"
+    t.integer "response_code"
+    t.string "on_queue_error"
+    t.index ["expired_at"], name: "index_asyncapi_client_jobs_on_expired_at"
+    t.index ["time_out_at"], name: "index_asyncapi_client_jobs_on_time_out_at"
   end
-
-  add_index "asyncapi_client_jobs", ["time_out_at"], name: "index_asyncapi_client_jobs_on_time_out_at"
 
 end


### PR DESCRIPTION
### Changes Proposed in this Pull Request:
* Add a more efficient method to create `JobCleanerWorker`s
* Add logic to deal with missing remote job information
* Update migrations to work with Rails 5 (the Rails 5 bump was made a few months ago, but the migrations weren't changed to work with this version)

### Important Links (Pivotal, Additional Repositories, etc):
* PT #163986377

### Additional Information (Optional)
* Bump to non beta version when merging to master
