### PR TITLE
Fix expired_at slow index on jobs table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.8.1] - 2019-03-04
+### Removed
+- Removed index to jobs table on `expired_at` attribute, with so many updates, it is non performant.
+
 ## [0.8.0] - 2019-02-18
 ### Changed
 - Fixes jobs deletion in cleanup when there are remote job parameters missing.

--- a/db/migrate/20190304200630_remove_expired_at_index_on_asyncapi_client_jobs.rb
+++ b/db/migrate/20190304200630_remove_expired_at_index_on_asyncapi_client_jobs.rb
@@ -1,0 +1,5 @@
+class RemoveExpiredAtIndexOnAsyncapiClientJobs < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :asyncapi_client_jobs, :expired_at
+  end
+end

--- a/lib/asyncapi/client/version.rb
+++ b/lib/asyncapi/client/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Client
-    VERSION = "0.8.0".freeze
+    VERSION = "0.8.1".freeze
   end
 end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_18_200630) do
+ActiveRecord::Schema.define(version: 2019_03_04_200630) do
 
   create_table "asyncapi_client_jobs", force: :cascade do |t|
     t.string "server_job_url"
@@ -31,7 +31,6 @@ ActiveRecord::Schema.define(version: 2019_02_18_200630) do
     t.string "on_time_out"
     t.integer "response_code"
     t.string "on_queue_error"
-    t.index ["expired_at"], name: "index_asyncapi_client_jobs_on_expired_at"
     t.index ["time_out_at"], name: "index_asyncapi_client_jobs_on_time_out_at"
   end
 


### PR DESCRIPTION
Removes non performant `expired_at` index.