### PR TITLE
Cleanup jobs after success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## TBD [0.8.2-alpha.1] - 2019-05-05
+### Added
+- Added `succeeded_job_deletion_threshold` configuration option to set the time after a succeeded job should be deleted.
+- Jobs now schedule a cleanup job to delete themselves in `succeeded_job_deletion_threshold`-time after succees.
+
+### Changed
+- Replaced occurrences of `have_enqueued_job` to `have_enqueued_sidekiq_job` in specs to avoid deprecation notices and name clashes with ActiveJob.
+
 ## [0.8.1] - 2019-03-04
 ### Removed
 - Removed index to jobs table on `expired_at` attribute, with so many updates, it is non performant.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## TBD [0.8.2-alpha.1] - 2019-05-05
+## TBD [0.9.0-alpha.1] - 2019-05-05
 ### Added
-- Added `succeeded_job_deletion_threshold` configuration option to set the time after a succeeded job should be deleted.
-- Jobs now schedule a cleanup job to delete themselves in `succeeded_job_deletion_threshold`-time after succees.
+- Added `successful_jobs_deletion_after` configuration option to set the time after a succeeded job should be deleted.
+- Jobs now schedule a cleanup job to delete themselves in `successful_jobs_deletion_after`-time after succees.
 
 ### Changed
 - Replaced occurrences of `have_enqueued_job` to `have_enqueued_sidekiq_job` in specs to avoid deprecation notices and name clashes with ActiveJob.

--- a/README.md
+++ b/README.md
@@ -73,9 +73,11 @@ There is a feed of all jobs that can be accessed via `/asyncapi/client/v1/jobs.j
 
 ## Expiry
 
-To make space in the database, old jobs must be deleted. By default, jobs older than 10 days will be deleted in both the Asyncapi Client and Asyncapi Server. Asyncapi Client is responsible for deleting the jobs it no longer needs a response from on the server.
+To make space in the database, old jobs must be deleted. By default, jobs older than 4 days will be deleted in both the Asyncapi Client and Asyncapi Server. Asyncapi Client is responsible for deleting the jobs it no longer needs a response from on the server.
 
-By default, jobs 10 days old and older will be deleted. You can change this setting by putting this in an initializer:
+**Important:** keep in mind that this setting may conflict with the `successful_jobs_deletion_after` setting with jobs in `success` state, which normally are deleted after they reach this state (see [Successful jobs automatic deletion](#successful-jobs-automatic-deletion) for more information).
+
+By default, jobs 4 days old and older will be deleted. You can change this setting by putting this in an initializer:
 
 ```ruby
 Asyncapi::Client.expiry_threshold = 5.days
@@ -88,6 +90,16 @@ The cleaner job is run every day at "0 0 * * *". If you want to change the frequ
 ```ruby
 Asyncapi::Client.clean_job_cron = "30 2 * * *"
 ```
+
+## Successful jobs automatic deletion
+
+After a job completes successfully, we schedule another job to delete it after a brief period of time to avoid having a lot of records on the table. By default, a successful job is deleted from the table after 2 minutes, ignoring the `expiry_threshold` configuration option. You can change this setting using the `successful_jobs_deletion_after` configuration option in an initializer if you want to extend or shorten the wait time for deletion:
+
+```ruby
+Asyncapi::Client.successful_jobs_deletion_after = 3.days
+```
+
+**Important:** if you want to ignore `successful_jobs_deletion_after` setting in favor of `expiry_threshold`, set `successful_jobs_deletion_after` to a value greater than `expiry_threshold`.
 
 # Installation
 

--- a/app/models/asyncapi/client/job.rb
+++ b/app/models/asyncapi/client/job.rb
@@ -90,7 +90,7 @@ module Asyncapi::Client
     def schedule_for_deletion
       if success?
         # delete in a couple of minutes, giving time for the success to be broadcasted
-        JobCleanerWorker.perform_in(Asyncapi::Client.succeeded_job_deletion_threshold, self.id)
+        JobCleanerWorker.perform_in(Asyncapi::Client.successful_jobs_deletion_after, self.id)
       end
     end
 

--- a/app/models/asyncapi/client/job.rb
+++ b/app/models/asyncapi/client/job.rb
@@ -21,7 +21,7 @@ module Asyncapi::Client
         transitions from: :fresh, to: :queued
       end
 
-      event :succeed do
+      event :succeed, after: :schedule_for_deletion do
         transitions from: :queued, to: :success
       end
 
@@ -86,6 +86,13 @@ module Asyncapi::Client
     end
 
     private
+
+    def schedule_for_deletion
+      if success?
+        # delete in a couple of minutes, giving time for the success to be broadcasted
+        JobCleanerWorker.perform_in(Asyncapi::Client.succeeded_job_deletion_threshold, self.id)
+      end
+    end
 
     def set_expired_at
       self.expired_at ||= Asyncapi::Client.expiry_threshold.from_now

--- a/lib/asyncapi/client.rb
+++ b/lib/asyncapi/client.rb
@@ -10,9 +10,10 @@ require "securerandom"
 module Asyncapi
   module Client
 
-    CONFIG_ATTRS = %i[parent_controller expiry_threshold clean_job_cron]
+    CONFIG_ATTRS = %i[parent_controller expiry_threshold clean_job_cron succeeded_job_deletion_threshold]
     mattr_accessor(*CONFIG_ATTRS)
-    self.expiry_threshold = 10.days
+    self.expiry_threshold = 4.days
+    self.succeeded_job_deletion_threshold = 2.minutes
     self.clean_job_cron = "0 0 * * *"
 
     def self.configure

--- a/lib/asyncapi/client.rb
+++ b/lib/asyncapi/client.rb
@@ -10,10 +10,10 @@ require "securerandom"
 module Asyncapi
   module Client
 
-    CONFIG_ATTRS = %i[parent_controller expiry_threshold clean_job_cron succeeded_job_deletion_threshold]
+    CONFIG_ATTRS = %i[parent_controller expiry_threshold clean_job_cron successful_jobs_deletion_after]
     mattr_accessor(*CONFIG_ATTRS)
     self.expiry_threshold = 4.days
-    self.succeeded_job_deletion_threshold = 2.minutes
+    self.successful_jobs_deletion_after = 2.minutes
     self.clean_job_cron = "0 0 * * *"
 
     def self.configure

--- a/lib/asyncapi/client/version.rb
+++ b/lib/asyncapi/client/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Client
-    VERSION = "0.8.1".freeze
+    VERSION = "0.8.2-alpha.1".freeze
   end
 end

--- a/lib/asyncapi/client/version.rb
+++ b/lib/asyncapi/client/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Client
-    VERSION = "0.8.2-alpha.1".freeze
+    VERSION = "0.9.0-alpha.1".freeze
   end
 end

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -24,8 +24,14 @@ module Asyncapi
     end
 
     describe ".expiry_threshold" do
-      it "defaults to 10 days" do
-        expect(described_class.expiry_threshold).to eq 10.days
+      it "defaults to 4 days" do
+        expect(described_class.expiry_threshold).to eq 4.days
+      end
+    end
+
+    describe ".succeeded_job_deletion_threshold" do
+      it "defaults to 2 minutes" do
+        expect(described_class.succeeded_job_deletion_threshold).to eq 2.minutes
       end
     end
 

--- a/spec/lib/client_spec.rb
+++ b/spec/lib/client_spec.rb
@@ -29,9 +29,9 @@ module Asyncapi
       end
     end
 
-    describe ".succeeded_job_deletion_threshold" do
+    describe ".successful_jobs_deletion_after" do
       it "defaults to 2 minutes" do
-        expect(described_class.succeeded_job_deletion_threshold).to eq 2.minutes
+        expect(described_class.successful_jobs_deletion_after).to eq 2.minutes
       end
     end
 

--- a/spec/models/job_spec.rb
+++ b/spec/models/job_spec.rb
@@ -274,7 +274,7 @@ module Asyncapi::Client
 
     it 'schedules a cleanup job for this job after success' do
       job.succeed!
-      expect(JobCleanerWorker).to have_enqueued_sidekiq_job(job.id).in(Asyncapi::Client.succeeded_job_deletion_threshold)
+      expect(JobCleanerWorker).to have_enqueued_sidekiq_job(job.id).in(Asyncapi::Client.successful_jobs_deletion_after)
     end
 
     context 'when the job is not in success state' do

--- a/spec/services/update_job_spec.rb
+++ b/spec/services/update_job_spec.rb
@@ -17,7 +17,7 @@ module Asyncapi::Client
         job.reload
 
         expect(job.message).to eq "Great success"
-        expect(JobStatusWorker).to_not have_enqueued_job(job.id)
+        expect(JobStatusWorker).to_not have_enqueued_sidekiq_job(job.id)
       end
     end
 
@@ -36,7 +36,7 @@ module Asyncapi::Client
 
         expect(job).to be_success
         expect(job.message).to eq "Great success"
-        expect(JobStatusWorker).to have_enqueued_job(job.id)
+        expect(JobStatusWorker).to have_enqueued_sidekiq_job(job.id)
       end
 
       it "can mark it as error" do
@@ -51,7 +51,7 @@ module Asyncapi::Client
 
         expect(job).to be_error
         expect(job.message).to eq "Failure there"
-        expect(JobStatusWorker).to have_enqueued_job(job.id)
+        expect(JobStatusWorker).to have_enqueued_sidekiq_job(job.id)
       end
     end
 
@@ -72,7 +72,7 @@ module Asyncapi::Client
 
         expect(job).to be_success
         expect(job.message).to eq "Ok"
-        expect(JobStatusWorker).to_not have_enqueued_job
+        expect(JobStatusWorker).to_not have_enqueued_sidekiq_job
       end
     end
 

--- a/spec/workers/cleaner_worker_spec.rb
+++ b/spec/workers/cleaner_worker_spec.rb
@@ -15,9 +15,9 @@ module Asyncapi
 
         described_class.new.perform
 
-        expect(JobCleanerWorker).to have_enqueued_job(deleted_job_1.id)
-        expect(JobCleanerWorker).to_not have_enqueued_job(kept_job.id)
-        expect(JobCleanerWorker).to have_enqueued_job(deleted_job_2.id)
+        expect(JobCleanerWorker).to have_enqueued_sidekiq_job(deleted_job_1.id)
+        expect(JobCleanerWorker).to_not have_enqueued_sidekiq_job(kept_job.id)
+        expect(JobCleanerWorker).to have_enqueued_sidekiq_job(deleted_job_2.id)
       end
 
     end

--- a/spec/workers/job_time_out_worker_spec.rb
+++ b/spec/workers/job_time_out_worker_spec.rb
@@ -31,7 +31,7 @@ module Asyncapi::Client
         expect(job_2_timed_out.reload.status).to eq "timed_out"
         expect(job_3_successful.reload.status).to eq "success"
         expect(job_4_never_time_out.reload.status).to_not eq "timed_out"
-        expect(JobStatusWorker).to have_enqueued_job(job_2_timed_out.id)
+        expect(JobStatusWorker).to have_enqueued_sidekiq_job(job_2_timed_out.id)
       end
     end
 


### PR DESCRIPTION
- Adds configuration option to set the deletion time of a successful job.
- Schedules a deletion after a job succeeds

Pivotal story: https://www.pivotaltracker.com/story/show/165800577