### PR TITLE
Explicitly skip auth check on JobsController#update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## TBD [0.10.1] - 2021-04-14
+### Changed
+- Explicitly skip `#authenticate_user` check for `JobsController#update`. This is already the case since `#report_job_status` from `Asyncapi::Server` does not make an effort to secure any form of secure token/authorization.
+
 ## [0.10.0] - 2021-01-20
 ### Changed
 - Update Ruby to 2.6.5

--- a/app/controllers/asyncapi/client/v1/jobs_controller.rb
+++ b/app/controllers/asyncapi/client/v1/jobs_controller.rb
@@ -2,6 +2,7 @@ module Asyncapi::Client
   module V1
     class JobsController < Asyncapi::Client.parent_controller
       include Rails::Pagination
+      skip_before_action :authenticate_user!, only: :update
 
       def index
         jobs = Job.all

--- a/lib/asyncapi/client/version.rb
+++ b/lib/asyncapi/client/version.rb
@@ -1,5 +1,5 @@
 module Asyncapi
   module Client
-    VERSION = "0.10.0".freeze
+    VERSION = "0.10.1-alpha.07".freeze
   end
 end


### PR DESCRIPTION
### Explicitly skip `authenticate_user!` check for `JobsController#update`. 

This is already the case since `#report_job_status` from `Asyncapi::Server` does not make an effort to secure any form of secure token/authorization.